### PR TITLE
Fix crashes & resetting effects

### DIFF
--- a/src/main/java/net/ldm/mo_enchants/enchantment/helpers/AquaphobiaCurseHelper.java
+++ b/src/main/java/net/ldm/mo_enchants/enchantment/helpers/AquaphobiaCurseHelper.java
@@ -11,9 +11,6 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.block.LiquidBlock;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class AquaphobiaCurseHelper {
 	public static void execute( LevelAccessor world, double x, double y, double z, Entity entity) {
@@ -33,34 +30,12 @@ public class AquaphobiaCurseHelper {
 				(entity instanceof LivingEntity _entGetArmor
 						? _entGetArmor.getItemBySlot(EquipmentSlot.FEET)
 						: ItemStack.EMPTY)) != 0)) {
-			if (!entity.getPersistentData().getBoolean("aquaphobiaDamageCooldown")) {
+
+			if (entity.getLevel().getGameTime() - entity.getPersistentData().getLong("aquaphobiaDamageTriggerTime")
+					> 10) {
+				entity.getPersistentData().putLong("aquaphobiaDamageTriggerTime", entity.getLevel().getGameTime());
 				if (entity instanceof LivingEntity _entity)
 					_entity.hurt(new DamageSource("curse.aquaphobia").bypassArmor(), 1);
-				entity.getPersistentData().putBoolean("aquaphobiaDamageCooldown", (true));
-			} else {
-				new Object() {
-					private int ticks = 0;
-					private float waitTicks;
-
-					public void start(int waitTicks) {
-						this.waitTicks = waitTicks;
-						MinecraftForge.EVENT_BUS.register(this);
-					}
-
-					@SubscribeEvent
-					public void tick(TickEvent.ServerTickEvent event) {
-						if (event.phase == TickEvent.Phase.END) {
-							this.ticks += 1;
-							if (this.ticks >= this.waitTicks)
-								run();
-						}
-					}
-
-					private void run() {
-						entity.getPersistentData().putBoolean("aquaphobiaDamageCooldown", (false));
-						MinecraftForge.EVENT_BUS.unregister(this);
-					}
-				}.start(10);
 			}
 		}
 	}

--- a/src/main/java/net/ldm/mo_enchants/enchantment/helpers/BloodthirstHelper.java
+++ b/src/main/java/net/ldm/mo_enchants/enchantment/helpers/BloodthirstHelper.java
@@ -26,10 +26,10 @@ public class BloodthirstHelper {
 		if (entity == null) return;
 		if (EnchantmentHelper.getTagEnchantmentLevel(MoEnchantsEnchantments.BLOODTHIRST.get(), (entity instanceof LivingEntity livingEntity ? livingEntity.getMainHandItem() : ItemStack.EMPTY)) <= 0) return;
 
-		if (!entity.getPersistentData().getBoolean("bloodthirstAbilityCooldown")) {
-			entity.getPersistentData().putBoolean("bloodthirstAbilityCooldown", true);
+		if (entity.getLevel().getGameTime() - entity.getPersistentData().getLong("bloodthirstAbilityTriggerTime")
+				> 240) {
+			entity.getPersistentData().putLong("bloodthirstAbilityTriggerTime", entity.getLevel().getGameTime());
 
-			// if not on cooldown - starts here
 			if (entity instanceof LivingEntity livingEntity) {
 				livingEntity.hurt(new DamageSource("enchantment.bloodthirst").bypassArmor(), 5);
 				livingEntity.addEffect(new MobEffectInstance(MobEffects.DAMAGE_BOOST, 240, EnchantmentHelper.getTagEnchantmentLevel(MoEnchantsEnchantments.BLOODTHIRST.get(), livingEntity.getMainHandItem())));
@@ -48,31 +48,6 @@ public class BloodthirstHelper {
 							SoundSource.PLAYERS, 1, 0.8f, false);
 				}
 			}
-			// if not on cooldown - ends here
-
-			new Object() {
-				private int ticks = 0;
-				private float waitTicks;
-
-				public void start(int waitTicks) {
-					this.waitTicks = waitTicks;
-					MinecraftForge.EVENT_BUS.register(this);
-				}
-
-				@SubscribeEvent
-				public void tick(TickEvent.ServerTickEvent event) {
-					if (event.phase == TickEvent.Phase.END) {
-						this.ticks += 1;
-						if (this.ticks >= this.waitTicks)
-							run();
-					}
-				}
-
-				private void run() {
-					entity.getPersistentData().putBoolean("bloodthirstAbilityCooldown", false);
-					MinecraftForge.EVENT_BUS.unregister(this);
-				}
-			}.start(240);
 		} else {
 			if (entity instanceof Player player && !player.level.isClientSide())
 				player.displayClientMessage(Component.translatable("cooldown.input", Component.translatable("enchantment.mo_enchants.bloodthirst")), true);

--- a/src/main/java/net/ldm/mo_enchants/enchantment/helpers/DensityCurseHelper.java
+++ b/src/main/java/net/ldm/mo_enchants/enchantment/helpers/DensityCurseHelper.java
@@ -15,12 +15,12 @@ public class DensityCurseHelper {
 		if (event.getSlot().equals(EquipmentSlot.HEAD) || event.getSlot().equals(EquipmentSlot.CHEST) || event.getSlot().equals(EquipmentSlot.LEGS) || event.getSlot().equals(EquipmentSlot.FEET)) {
 			final AttributeInstance attributeInstance = event.getEntity().getAttributes().getInstance(ForgeMod.ENTITY_GRAVITY.get());
 
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:density_curse\",lvl:1s}") && !attributeInstance.hasModifier(densityCurse)) {
-				attributeInstance.addPermanentModifier(densityCurse);
-			}
-
 			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:density_curse\",lvl:1s}") && attributeInstance.hasModifier(densityCurse)) {
 				attributeInstance.removePermanentModifier(densityCurse.getId());
+			}
+
+			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:density_curse\",lvl:1s}") && !attributeInstance.hasModifier(densityCurse)) {
+				attributeInstance.addPermanentModifier(densityCurse);
 			}
 		}
 	}

--- a/src/main/java/net/ldm/mo_enchants/enchantment/helpers/GrowthHelper.java
+++ b/src/main/java/net/ldm/mo_enchants/enchantment/helpers/GrowthHelper.java
@@ -19,36 +19,30 @@ public class GrowthHelper {
 				event.getSlot().equals(EquipmentSlot.LEGS) || event.getSlot().equals(EquipmentSlot.FEET)) {
 			final AttributeInstance attributeInstance = event.getEntity().getAttributes().getInstance(Attributes.MAX_HEALTH);
 
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:1s}") && !attributeInstance.hasModifier(growthEnchantmentLv1)) {
-				attributeInstance.addPermanentModifier(growthEnchantmentLv1);
-			}
-
 			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:1s}") && attributeInstance.hasModifier(growthEnchantmentLv1)) {
 				attributeInstance.removePermanentModifier(growthEnchantmentLv1.getId());
 			}
-
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:2s}") && !attributeInstance.hasModifier(growthEnchantmentLv2)) {
-				attributeInstance.addPermanentModifier(growthEnchantmentLv2);
-			}
-
-			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:2s}") && attributeInstance.hasModifier(growthEnchantmentLv2)) {
+			else if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:2s}") && attributeInstance.hasModifier(growthEnchantmentLv2)) {
 				attributeInstance.removePermanentModifier(growthEnchantmentLv2.getId());
 			}
-
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:3s}") && !attributeInstance.hasModifier(growthEnchantmentLv3)) {
-				attributeInstance.addPermanentModifier(growthEnchantmentLv3);
-			}
-
-			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:3s}") && attributeInstance.hasModifier(growthEnchantmentLv3)) {
+			else if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:3s}") && attributeInstance.hasModifier(growthEnchantmentLv3)) {
 				attributeInstance.removePermanentModifier(growthEnchantmentLv3.getId());
 			}
-
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:4s}") && !attributeInstance.hasModifier(growthEnchantmentLv4)) {
-				attributeInstance.addPermanentModifier(growthEnchantmentLv4);
+			else if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:4s}") && attributeInstance.hasModifier(growthEnchantmentLv4)) {
+				attributeInstance.removePermanentModifier(growthEnchantmentLv4.getId());
 			}
 
-			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:4s}") && attributeInstance.hasModifier(growthEnchantmentLv4)) {
-				attributeInstance.removePermanentModifier(growthEnchantmentLv4.getId());
+			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:1s}") && !attributeInstance.hasModifier(growthEnchantmentLv1)) {
+				attributeInstance.addPermanentModifier(growthEnchantmentLv1);
+			}
+			else if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:2s}") && !attributeInstance.hasModifier(growthEnchantmentLv2)) {
+				attributeInstance.addPermanentModifier(growthEnchantmentLv2);
+			}
+			else if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:3s}") && !attributeInstance.hasModifier(growthEnchantmentLv3)) {
+				attributeInstance.addPermanentModifier(growthEnchantmentLv3);
+			}
+			else if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:growth\",lvl:4s}") && !attributeInstance.hasModifier(growthEnchantmentLv4)) {
+				attributeInstance.addPermanentModifier(growthEnchantmentLv4);
 			}
 		}
 	}

--- a/src/main/java/net/ldm/mo_enchants/enchantment/helpers/NightVisionHelper.java
+++ b/src/main/java/net/ldm/mo_enchants/enchantment/helpers/NightVisionHelper.java
@@ -10,13 +10,12 @@ import net.minecraftforge.event.entity.living.LivingEquipmentChangeEvent;
 
 public class NightVisionHelper {
 	public static void execute(LivingEquipmentChangeEvent event) {
-		if (event.getSlot().equals(EquipmentSlot.HEAD) && EnchantmentHelper.getTagEnchantmentLevel(MoEnchantsEnchantments.NIGHT_VISION.get(), event.getTo()) >= 1 &&
-				event.getEntity() instanceof Player) {
-			event.getEntity().addEffect(new MobEffectInstance(MobEffects.NIGHT_VISION, 2147483647, 0, false, false, false));
+		if (event.getSlot().equals(EquipmentSlot.HEAD) && event.getEntity() instanceof Player) {
+			if (EnchantmentHelper.getTagEnchantmentLevel(MoEnchantsEnchantments.NIGHT_VISION.get(), event.getTo()) >= 1) {
+				event.getEntity().addEffect(new MobEffectInstance(MobEffects.NIGHT_VISION, 2147483647, 0, false, false, false));
+			} else if (EnchantmentHelper.getTagEnchantmentLevel(MoEnchantsEnchantments.NIGHT_VISION.get(), event.getFrom()) >= 1) {
+				event.getEntity().removeEffect(MobEffects.NIGHT_VISION);
+			}
 		}
-
-		if (event.getSlot().equals(EquipmentSlot.HEAD) && EnchantmentHelper.getTagEnchantmentLevel(MoEnchantsEnchantments.NIGHT_VISION.get(), event.getFrom()) >= 1 &&
-				event.getEntity() instanceof Player)
-			event.getEntity().removeEffect(MobEffects.NIGHT_VISION);
 	}
 }

--- a/src/main/java/net/ldm/mo_enchants/enchantment/helpers/PanicHelper.java
+++ b/src/main/java/net/ldm/mo_enchants/enchantment/helpers/PanicHelper.java
@@ -13,9 +13,6 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import net.minecraft.world.level.LevelAccessor;
-import net.minecraftforge.common.MinecraftForge;
-import net.minecraftforge.event.TickEvent;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
 
 public class PanicHelper {
 	public static void execute(LevelAccessor world, LivingEntity entity) {
@@ -23,10 +20,10 @@ public class PanicHelper {
 		if (EnchantmentHelper.getTagEnchantmentLevel(MoEnchantsEnchantments.PANIC.get(), (entity.getItemBySlot(EquipmentSlot.FEET))) <= 0 || entity.getHealth() >= 8) return;
 		int enchLevel = EnchantmentHelper.getTagEnchantmentLevel(MoEnchantsEnchantments.PANIC.get(), (entity.getItemBySlot(EquipmentSlot.FEET)));
 
-		if (!entity.getPersistentData().getBoolean("panicEnchantmentCooldown")) {
-			entity.getPersistentData().putBoolean("panicEnchantmentCooldown", true);
+		if (entity.getLevel().getGameTime() - entity.getPersistentData().getLong("panicEnchantmentTriggerTime")
+				> 240 / enchLevel) {
+			entity.getPersistentData().putLong("panicEnchantmentTriggerTime", entity.getLevel().getGameTime());
 
-			// if not on cooldown - starts here
 			entity.setHealth(7);
 			entity.addEffect(new MobEffectInstance(MobEffects.REGENERATION, (enchLevel * 40), enchLevel));
 			entity.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, (enchLevel * 40), enchLevel));
@@ -40,31 +37,6 @@ public class PanicHelper {
 				item.shrink(1);
 				item.setDamageValue(0);
 			}
-			// if not on cooldown - ends here
-
-			new Object() {
-				private int ticks = 0;
-				private float waitTicks;
-
-				public void start(int waitTicks) {
-					this.waitTicks = waitTicks;
-					MinecraftForge.EVENT_BUS.register(this);
-				}
-
-				@SubscribeEvent
-				public void tick( TickEvent.ServerTickEvent event) {
-					if (event.phase == TickEvent.Phase.END) {
-						this.ticks += 1;
-						if (this.ticks >= this.waitTicks)
-							run();
-					}
-				}
-
-				private void run() {
-					entity.getPersistentData().putBoolean("panicEnchantmentCooldown", false);
-					MinecraftForge.EVENT_BUS.unregister(this);
-				}
-			}.start(240 / enchLevel);
 		} else {
 			if (entity instanceof Player player && !player.level.isClientSide())
 				player.displayClientMessage(Component.translatable("cooldown.input", Component.translatable("enchantment.mo_enchants.panic")), true);

--- a/src/main/java/net/ldm/mo_enchants/enchantment/helpers/ReachHelper.java
+++ b/src/main/java/net/ldm/mo_enchants/enchantment/helpers/ReachHelper.java
@@ -17,28 +17,24 @@ public class ReachHelper {
 		if (event.getSlot().equals(EquipmentSlot.MAINHAND)) {
 			final AttributeInstance attributeInstance = event.getEntity().getAttributes().getInstance(ForgeMod.REACH_DISTANCE.get());
 
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:1s}") && !attributeInstance.hasModifier(reachEnchantmentLv1)) {
-				attributeInstance.addPermanentModifier(reachEnchantmentLv1);
-			}
-
 			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:1s}") && attributeInstance.hasModifier(reachEnchantmentLv1)) {
 				attributeInstance.removePermanentModifier(reachEnchantmentLv1.getId());
 			}
-
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:2s}") && !attributeInstance.hasModifier(reachEnchantmentLv2)) {
-				attributeInstance.addPermanentModifier(reachEnchantmentLv2);
-			}
-
-			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:2s}") && attributeInstance.hasModifier(reachEnchantmentLv2)) {
+			else if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:2s}") && attributeInstance.hasModifier(reachEnchantmentLv2)) {
 				attributeInstance.removePermanentModifier(reachEnchantmentLv2.getId());
 			}
-
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:3s}") && !attributeInstance.hasModifier(reachEnchantmentLv3)) {
-				attributeInstance.addPermanentModifier(reachEnchantmentLv3);
+			else if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:3s}") && attributeInstance.hasModifier(reachEnchantmentLv3)) {
+				attributeInstance.removePermanentModifier(reachEnchantmentLv3.getId());
 			}
 
-			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:3s}") && attributeInstance.hasModifier(reachEnchantmentLv3)) {
-				attributeInstance.removePermanentModifier(reachEnchantmentLv3.getId());
+			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:1s}") && !attributeInstance.hasModifier(reachEnchantmentLv1)) {
+				attributeInstance.addPermanentModifier(reachEnchantmentLv1);
+			}
+			else if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:2s}") && !attributeInstance.hasModifier(reachEnchantmentLv2)) {
+				attributeInstance.addPermanentModifier(reachEnchantmentLv2);
+			}
+			else if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:reach\",lvl:3s}") && !attributeInstance.hasModifier(reachEnchantmentLv3)) {
+				attributeInstance.addPermanentModifier(reachEnchantmentLv3);
 			}
 		}
 	}

--- a/src/main/java/net/ldm/mo_enchants/enchantment/helpers/SwiftnessHelper.java
+++ b/src/main/java/net/ldm/mo_enchants/enchantment/helpers/SwiftnessHelper.java
@@ -17,28 +17,24 @@ public class SwiftnessHelper {
 		if (event.getSlot().equals(EquipmentSlot.FEET)) {
 			final AttributeInstance attributeInstance = event.getEntity().getAttributes().getInstance(Attributes.MOVEMENT_SPEED);
 
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:1s}") && !attributeInstance.hasModifier(swiftnessEnchantmentLv1)) {
-				attributeInstance.addPermanentModifier(swiftnessEnchantmentLv1);
-			}
-
 			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:1s}") && attributeInstance.hasModifier(swiftnessEnchantmentLv1)) {
 				attributeInstance.removePermanentModifier(swiftnessEnchantmentLv1.getId());
 			}
-
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:2s}") && !attributeInstance.hasModifier(swiftnessEnchantmentLv2)) {
-				attributeInstance.addPermanentModifier(swiftnessEnchantmentLv2);
-			}
-
-			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:2s}") && attributeInstance.hasModifier(swiftnessEnchantmentLv2)) {
+			else if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:2s}") && attributeInstance.hasModifier(swiftnessEnchantmentLv2)) {
 				attributeInstance.removePermanentModifier(swiftnessEnchantmentLv2.getId());
 			}
-
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:3s}") && !attributeInstance.hasModifier(swiftnessEnchantmentLv3)) {
-				attributeInstance.addPermanentModifier(swiftnessEnchantmentLv3);
+			else if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:3s}") && attributeInstance.hasModifier(swiftnessEnchantmentLv3)) {
+				attributeInstance.removePermanentModifier(swiftnessEnchantmentLv3.getId());
 			}
 
-			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:3s}") && attributeInstance.hasModifier(swiftnessEnchantmentLv3)) {
-				attributeInstance.removePermanentModifier(swiftnessEnchantmentLv3.getId());
+			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:1s}") && !attributeInstance.hasModifier(swiftnessEnchantmentLv1)) {
+				attributeInstance.addPermanentModifier(swiftnessEnchantmentLv1);
+			}
+			else if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:2s}") && !attributeInstance.hasModifier(swiftnessEnchantmentLv2)) {
+				attributeInstance.addPermanentModifier(swiftnessEnchantmentLv2);
+			}
+			else if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:swiftness\",lvl:3s}") && !attributeInstance.hasModifier(swiftnessEnchantmentLv3)) {
+				attributeInstance.addPermanentModifier(swiftnessEnchantmentLv3);
 			}
 		}
 	}

--- a/src/main/java/net/ldm/mo_enchants/enchantment/helpers/WeightlessHelper.java
+++ b/src/main/java/net/ldm/mo_enchants/enchantment/helpers/WeightlessHelper.java
@@ -16,20 +16,18 @@ public class WeightlessHelper {
 		if (event.getSlot().equals(EquipmentSlot.LEGS)) {
 			final AttributeInstance attributeInstance = event.getEntity().getAttributes().getInstance(ForgeMod.ENTITY_GRAVITY.get());
 
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:weightless\",lvl:1s}") && !attributeInstance.hasModifier(weightlessEnchantmentLv1)) {
-				attributeInstance.addPermanentModifier(weightlessEnchantmentLv1);
-			}
-
 			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:weightless\",lvl:1s}") && attributeInstance.hasModifier(weightlessEnchantmentLv1)) {
 				attributeInstance.removePermanentModifier(weightlessEnchantmentLv1.getId());
 			}
-
-			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:weightless\",lvl:2s}") && !attributeInstance.hasModifier(weightlessEnchantmentLv2)) {
-				attributeInstance.addPermanentModifier(weightlessEnchantmentLv2);
+			else if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:weightless\",lvl:2s}") && attributeInstance.hasModifier(weightlessEnchantmentLv2)) {
+				attributeInstance.removePermanentModifier(weightlessEnchantmentLv2.getId());
 			}
 
-			if (attributeInstance != null && event.getFrom().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:weightless\",lvl:2s}") && attributeInstance.hasModifier(weightlessEnchantmentLv2)) {
-				attributeInstance.removePermanentModifier(weightlessEnchantmentLv2.getId());
+			if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:weightless\",lvl:1s}") && !attributeInstance.hasModifier(weightlessEnchantmentLv1)) {
+				attributeInstance.addPermanentModifier(weightlessEnchantmentLv1);
+			}
+			else if (attributeInstance != null && event.getTo().getEnchantmentTags().getAsString().contains("{id:\"mo_enchants:weightless\",lvl:2s}") && !attributeInstance.hasModifier(weightlessEnchantmentLv2)) {
+				attributeInstance.addPermanentModifier(weightlessEnchantmentLv2);
 			}
 		}
 	}


### PR DESCRIPTION
* Changed how cooldowns work, because game was crashing if there are several different cooldowns running at the same time. For example, when entity stands in water with panic and aquaphobia boots.
* Changed how effects applied on equipmentChangeEvent, fixes #11.